### PR TITLE
MacOSの場合使用するフォントを設定

### DIFF
--- a/root.go
+++ b/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"image/color"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -23,7 +24,12 @@ func init() {
 format is [black|red|green|yellow|blue|magenta|cyan|white]
 or (R,G,B,A(0~255))`)
 	RootCommand.Flags().StringP("out", "o", "", "output image file path")
-	RootCommand.Flags().StringP("fontfile", "f", "/usr/share/fonts/truetype/vlgothic/VL-Gothic-Regular.ttf", "font file path")
+
+	font := "/usr/share/fonts/truetype/vlgothic/VL-Gothic-Regular.ttf"
+	if runtime.GOOS == "darwin" {
+		font = "/Library/Fonts/AppleGothic.ttf"
+	}
+	RootCommand.Flags().StringP("fontfile", "f", font, "font file path")
 	RootCommand.Flags().IntP("fontsize", "F", 64, "font size")
 }
 


### PR DESCRIPTION
Macだと-fなしではフォントファイルが見つからずpanicになるので、初期値を追加しました