### PR TITLE
タブをスペース2つで描画するように修正

### DIFF
--- a/root.go
+++ b/root.go
@@ -236,6 +236,10 @@ var RootCommand = &cobra.Command{
 
 		encFmt, err := getEncodeFormat(outpath)
 
+		for i, text := range texts {
+			texts[i] = strings.Replace(text, "\t", "  ", -1)
+		}
+
 		writeImage(w, encFmt, texts, appconf)
 	},
 }


### PR DESCRIPTION
タブ文字がうまく描画されていなかったので、暫定的にスペース2個に置換するようにしました。