### PR TITLE
アニメーションGIFをパイプ出力できるように

### DIFF
--- a/root.go
+++ b/root.go
@@ -265,7 +265,11 @@ var RootCommand = &cobra.Command{
 				return errors.New("No output target error")
 			}
 			w = os.Stdout
-			imgExt = ".png"
+			if useAnimation {
+				imgExt = ".gif"
+			} else {
+				imgExt = ".png"
+			}
 		} else {
 			var err error
 			w, err = os.Create(appconf.Outpath)


### PR DESCRIPTION
Qiita の記事 (https://qiita.com/yami_buta/items/e18508b04ef9e300775f) を見て、textimg の出力するアニメーションをパイプで img2sixel に渡せたら素敵だなと思いました。

img2sixel の方がtextimgが出力するGIFに対応してなかったので、 https://github.com/saitoha/libsixel/issues/115 で報告し、対応いただきました。

一方、textimg では出力がパイプの場合に png 決め打ちになっていたため、 -a オプションを指定した場合には gif として扱うようにする必要がありました。それを対応しています。

libsixel の修正版との組み合わせで macOS の iTerm2 でアニメーション表示ができるのを確認済みです:

```
$ echo -en {,,,,,,,,,,}{,,,,,,,,,,}"\U1f32"{{4..9},{9..4..-1}}|tr -d ' '|grep -Eo .'{1,11}'|bin/textimg -al11 -F40 -d8 | ../libsixel/converters/img2sixel
```