### PR TITLE
Update root.go

### DIFF
--- a/root.go
+++ b/root.go
@@ -132,7 +132,7 @@ func (a *applicationConfig) setFontFileAndFontIndex(runtimeOS string) {
 		},
 		"android": {
 			fontFile:  defaultAndroidFont,
-			fontIndex: 4,
+			fontIndex: 5,
 		},
 	}
 
@@ -154,7 +154,7 @@ func (a *applicationConfig) setFontFileAndFontIndex(runtimeOS string) {
 		if _, err := os.Stat(a.FontFile); err != nil {
 			a.FontFile = defaultLinuxFont2
 		}
-		a.FontIndex = 4
+		a.FontIndex = 5
 		return
 	}
 }

--- a/root_test.go
+++ b/root_test.go
@@ -330,13 +330,13 @@ func TestApplicationConfigSetFontFileAndFontIndex(t *testing.T) {
 			desc:          "正常系: フォント未設定でandroidの場合はandroid用のフォントが設定される",
 			inRuntimeOS:   "android",
 			wantFontFile:  defaultAndroidFont,
-			wantFontIndex: 4,
+			wantFontIndex: 5,
 		},
 		{
 			desc:          "正常系: フォント未設定でlinuxの場合はlinux用のフォントが設定される。Linux用のフォントは2つ存在するが、1つ目のフォントはalpineコンテナ内にデフォルトでは存在しないため2つ目が設定される",
 			inRuntimeOS:   "linux",
 			wantFontFile:  defaultLinuxFont2,
-			wantFontIndex: 4,
+			wantFontIndex: 5,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
完全に私のミスです。申し訳ありません。[このサイト](https://www.google.com/get/noto/help/cjk/)からダウンロードしたファイルで確認したため勘違いをしてしまいましたが、LinuxでもAndroidでも、(おそらく最新版と思われる)NotoSansCJK-Regular.ttcには10種類のフォントが含まれており、Noto Sans Mono CJK JPは6番目でした。