### PR TITLE
feat: Add arm64 unit test, and Creating arm64 binaries #262

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: release
 
 env:
   app: textimg
-  goversion: '1.18'
+  goversion: '1.21'
   build_opts: '-ldflags="-s -w -extldflags \"-static\""'
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, windows, darwin]
-        arch: [amd64]
+        arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         os: [linux, windows, darwin]
-        arch: [amd64]
+        arch: [amd64, arm64]
         include:
           - os: windows
             asset_content_type: application/zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,23 @@ jobs:
       - run: go install
       - run: go test -cover ./...
 
+  build-arm64:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+          - '1.x'
+        os:
+          - 'linux'
+          - 'darwin'
+          - 'windows'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 go build
+
   format:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - run: apt-get install -y gcc-aarch64-linux-gnu
+      - run: sudo apt-get install -y gcc-aarch64-linux-gnu
       - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build
 
   format:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ name: test
       - LICENSE
 
 env:
-  goversion: '1.18'
+  goversion: '1.21'
 
 jobs:
   test:
@@ -50,6 +50,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+      # if use CGO_ENABLED=1 then use this code.
+      #
       # - run: sudo apt-get install -y gcc-aarch64-linux-gnu
       # - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o textimg_${{ matrix.os }}_arm64
       - run: GOOS=${{ matrix.os }} GOARCH=arm64 go build -o textimg_${{ matrix.os }}_arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,8 @@ jobs:
           - '1.x'
         os:
           - 'linux'
-          - 'darwin'
-          - 'windows'
+          #- 'darwin'
+          #- 'windows'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.goversion }}
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
-        with:
-          version: v1.45
+      - name: Lint
+        run: go vet .
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,13 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - run: sudo apt-get install -y gcc-aarch64-linux-gnu
-      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build
+      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o textimg_${{ matrix.os }}_arm64
+      - run: gzip textimg_${{ matrix.os }}_arm64
+      - name: Upload artifact (windows)
+        uses: actions/upload-artifact@v4
+        with:
+          name: textimg_${{ matrix.os }}_arm64.gz
+          path: textimg_${{ matrix.os }}_arm64.gz
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 go build
+      - run: apt-get install -y gcc-aarch64-linux-gnu
+      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,16 @@ jobs:
           - '1.x'
         os:
           - 'linux'
-          #- 'darwin'
-          #- 'windows'
+          - 'darwin'
+          - 'windows'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-      - run: sudo apt-get install -y gcc-aarch64-linux-gnu
-      - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o textimg_${{ matrix.os }}_arm64
+      # - run: sudo apt-get install -y gcc-aarch64-linux-gnu
+      # - run: GOOS=${{ matrix.os }} GOARCH=arm64 CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc go build -o textimg_${{ matrix.os }}_arm64
+      - run: GOOS=${{ matrix.os }} GOARCH=arm64 go build -o textimg_${{ matrix.os }}_arm64
       - run: gzip textimg_${{ matrix.os }}_arm64
       - name: Upload artifact (windows)
         uses: actions/upload-artifact@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,0 @@
----
-
-linters-settings:
-  govet:
-    disable:
-      - composites

--- a/internal/global/version.go
+++ b/internal/global/version.go
@@ -2,7 +2,7 @@ package global
 
 const (
 	AppName = "textimg"
-	Version = `3.1.9
+	Version = `3.1.10
 Copyright (c) 2019 jiro4989
 Released under the MIT License.
 https://github.com/jiro4989/textimg`


### PR DESCRIPTION
## Overview

* Add CI workflow to test arm64
* Add CI workflow to upload arm64 binaries to GitHub Releases
* Upgrade go version in CI workflow (`1.18` → `1.21`)
* Change Lint tool (golangci-lint → `go vet`)
* Bump patch version (`3.1.9` → `3.1.10`)

#262 