### PR TITLE
fix(docker): Symbolaフォントの取得先を変更してCIが失敗する問題を修正する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM golang:1.26.4-alpine3.22 AS base
+FROM golang:1.26.4-bookworm AS base
 
 RUN go version \
     && echo $GOPATH \
-    && apk update \
-    && apk add --no-cache git wget unzip fontconfig alpine-sdk bash \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends git wget unzip fontconfig fonts-symbola \
+    && rm -rf /var/lib/apt/lists/* \
     && wget https://github.com/tomokuni/Myrica/raw/master/product/MyricaM.zip -q -O /tmp/MyricaM.zip \
     && (cd /tmp && unzip MyricaM.zip) \
     && git clone https://github.com/googlefonts/noto-emoji /usr/local/src/noto-emoji \
-    && wget https://www.wfonts.com/download/data/2016/04/23/symbola/symbola.zip -q -O /tmp/symbola.zip \
-    && (cd /tmp && unzip symbola.zip)
+    && cp /usr/share/fonts/truetype/ancient-scripts/Symbola_hint.ttf /tmp/
 
 ################################################################################
 


### PR DESCRIPTION
CI の `docker-test` で `symbola.zip` の wget が exit 8 で失敗し、Dependabot PR (#356, #365, #366) が滞留している問題の修正です。URL 自体は有効ですが、GitHub Actions ランナーからのアクセスが拒否されています。

### 変更内容 (Dockerfile のみ)
- base ステージを `golang:1.26.4-alpine3.22` から `golang:1.26.4-bookworm` に変更し、Symbola を `apt-get install fonts-symbola` で導入（実行ステージ `alpine:3.24.1` は変更なし）。
- 配置先は `config/config.go` の指定と一致し `/tmp/` にコピーされるため、テストや `docker-compose.yml` は変更していません。

### 補足
- ランナーからのアクセス拒否が原因のため fork 上の GitHub Actions で検証しました。修正前は fail していた `docker-test` を含む全ジョブの pass を確認済みです（テストと `docker-compose.yml` は未変更）。
- 実行結果: https://github.com/Khronos31/textimg/actions/runs/34028059979

他の選択肢（判断はお任せします）:
- Alpine のまま Symbola の別の配布元を探す
- フォントファイルをリポジトリに同梱する

なお、コード修正はClaude Code、PR本文はAntigravityで作成しましたが、投稿前に人間が最終チェックを行いました
